### PR TITLE
gha: run `apt update` before every `apt install`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -54,6 +54,7 @@ jobs:
           cache: pip
       - name: Install latest PlantUML
         run: |
+          sudo apt update
           sudo apt install -y default-jre graphviz
           sudo curl -fSLo /opt/plantuml.jar https://github.com/plantuml/plantuml/releases/latest/download/plantuml.jar
           sudo tee /usr/bin/plantuml <<'EOF'


### PR DESCRIPTION
The job failed with 404 while fetching OpenJDK from, I assume, an outdated
URL.

https://github.com/549531/project-integration/actions/runs/15027396592/job/42231423060#logs
