### PR TITLE
glove: change default env to `debug`

### DIFF
--- a/glove/platformio.ini
+++ b/glove/platformio.ini
@@ -9,6 +9,7 @@
 ; https://docs.platformio.org/page/projectconf.html
 
 [platformio]
+default_envs = debug
 src_dir = main
 
 [env]


### PR DESCRIPTION
By default, PlatformIO runs the command for all environments; in our
case, it doesn't make sense to e.g. deploy both debug and release at the
same time. I've set `debug` as default as that's what we're gonna work
with 99% of the time.
