### PR TITLE
api: disable debugging by default

### DIFF
--- a/api/api/settings.py
+++ b/api/api/settings.py
@@ -11,6 +11,7 @@ https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
 from pathlib import Path
+import os
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
 BASE_DIR = Path(__file__).resolve().parent.parent
@@ -23,7 +24,7 @@ BASE_DIR = Path(__file__).resolve().parent.parent
 SECRET_KEY = "django-insecure-t)2zc&3332jxqv%e%-+*h353-jy-x35*etc$y&(2wq+by5nd2l"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = True
+DEBUG = os.getenv("DJANGO_DEBUG") is not None
 
 ALLOWED_HOSTS = [
     "127.0.0.1",

--- a/process-compose.yaml
+++ b/process-compose.yaml
@@ -2,6 +2,8 @@ processes:
   api:
     command: uv run manage.py runserver 2948
     working_dir: api
+    environment:
+    - DJANGO_DEBUG=True
   docs:
     command: make livehtml
     working_dir: docs


### PR DESCRIPTION
Turn it back on by setting environment variable DJANGO_DEBUG to any
value.

Turned debugging back on in the development `process-compose.yaml`.
