### PR TITLE
Change Dependabot update schedule to monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,8 +7,20 @@ updates:
   - package-ecosystem: pip
     directory: /docs
     schedule:
-      interval: daily
+      interval: monthly
+  - package-ecosystem: pip
+    directory: /api
+    schedule:
+      interval: monthly
+  - package-ecosystem: npm
+    directory: /frontend
+    schedule:
+      interval: monthly
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: monthly
+  - package-ecosystem: nix
+    directory: /
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Updated Dependabot configuration to reduce update frequency for multiple ecosystems to monthly.

Added updates for API, frontend, and Nix.